### PR TITLE
Remove PyWin32 From Requirements File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ numpy==1.18.1
 platform-utils==0.41
 pyglet==1.4.10
 pytz==2019.3
-pywin32==227
 requests==2.22.0
 urllib3==1.25.8
 winpaths==0.2


### PR DESCRIPTION
I removed pywin32 from requirements.txt because the readme tells us not to install this package from PyPi, and to instead use the installer.