### PR TITLE
Fix autopilot and GPWS key conflict

### DIFF
--- a/flightFollowing.py
+++ b/flightFollowing.py
@@ -269,7 +269,7 @@ class FlightFollowing:
                 'dest_key': 'd',
                 'attitude_key': '[',
                 'manual_key': 'Ctrl+m',
-                'autopilot_key': 'shift+a',
+                'autopilot_key': 'shift+p',
                 'director_key': 'Ctrl+f',
                 'toggle_gpws_key': 'shift+a',
                 'toggle_ils_key': 'shift+i',


### PR DESCRIPTION
Shift+A was somehow assigned to both toggle autopilot announcements and GPWS callouts. Changes autopilot key to Shift+P.